### PR TITLE
reset_style implemented

### DIFF
--- a/examples/example_008.py
+++ b/examples/example_008.py
@@ -7,8 +7,21 @@ def start():
 
 def update():
     fill_screen("orange")
-    ellipse(50, 40, 50, 30, "red", "blue", 3)
 
-    ellipse(200, 200, 30, 50, stroke_width=10)
+    save()
+    translate(60,60)
+    rotate(T*2.5)
+    ellipse(0, 0, 50, 30, "red", "blue", 3)
+    restore()
 
-    ellipse(400, 400, 30, 100, "green")
+    save()
+    translate(200,200)
+    rotate(T*1.5+0.5)
+    ellipse(40*sin(T), 0, 30, 50, stroke_width=10)
+    restore()
+    
+    save()
+    translate(400,300)
+    rotate(T)
+    ellipse(0, 100*cos(T*2), 30, 100, "green")
+    restore()

--- a/pypen/drawing/fake_primitives.py
+++ b/pypen/drawing/fake_primitives.py
@@ -63,3 +63,9 @@ def save():
 def restore():
     """Restores the context's translation, rotation and scaling to that of the latest save"""
     raise NotImplementedError("restore() is not implemented")
+
+
+def reset_style():
+    """Resets PyPen's current setting surrounding style to their default_values, which includes fill_color, stroke_color, stroke_width"""
+    raise NotImplementedError("reset_style() is not implemented")
+

--- a/pypen/drawing/pypen_class.py
+++ b/pypen/drawing/pypen_class.py
@@ -2,6 +2,7 @@ import ctypes
 
 from pypen.drawing.color import Color
 from pypen.utils.math import TAU
+from pypen.settings import default_settings 
 import cairo
 from pyglet import gl, image
 
@@ -33,6 +34,8 @@ class PyPen():
         self.user_sketch.scale = self.scale
         self.user_sketch.save = self.save
         self.user_sketch.restore = self.restore
+
+        self.user_sketch.reset_style = self.reset_style
 
     def _fill(self, unparsed_fill_color):
         if unparsed_fill_color != "":
@@ -71,6 +74,11 @@ class PyPen():
     def restore(self):
         self.context.restore()
 
+    def reset_style(self):
+        self.user_sketch.settings.fill_color = default_settings.fill_color
+        self.user_sketch.settings.stroke_color = default_settings.stroke_color
+        self.user_sketch.settings.stroke_width = default_settings.stroke_width
+
     def update_settings(self):
         self.surface_data = (ctypes.c_ubyte * (self.user_sketch.settings.width * self.user_sketch.settings.height * 4))()
         self.surface = cairo.ImageSurface.create_for_data(self.surface_data,
@@ -88,9 +96,12 @@ class PyPen():
         self.clear_screen()
 
     def fill_screen(self, color="default_background_color"):
+        background_color = Color.from_user_input(color)
         self.context.save()
         self.context.scale(self.user_sketch.settings.width, self.user_sketch.settings.height)
-        self.rectangle(0, 0, 1, 1, color)
+        self.context.rectangle(0, 0, 1, 1)
+        self.context.set_source_rgba(*background_color.rgba())
+        self.context.fill()
         self.context.restore()
 
     def rectangle(self, x, y, width, height, fill_color="", stroke_color="", stroke_width=-1):

--- a/pypen/settings.py
+++ b/pypen/settings.py
@@ -1,4 +1,4 @@
-
+from copy import copy
 
 class Settings:
     def __init__(self, fps, width, height, default_pypen_name, _is_executing_with_python,
@@ -27,3 +27,5 @@ settings = Settings(width=640,
                     _is_executing_with_python=False,
                     _user_has_start=True,
                     _user_has_update=True)
+
+default_settings = copy(settings)


### PR DESCRIPTION
## How it works
```reset_style()``` sets the values of ```settings.fill_color```, ```settings.stroke_color``` and ```settings.stroke_width``` to their default values as specified by pypen/settings.py. 

## Example
```python
def update():
    fill_screen("green")

    circle(300, 100, 30)

    settings.fill_color = "red"
    circle(300, 300, 30)

    reset_style()
```
Here the circle at (300,100) would every frame be the color of "default_fill_color". If reset_style were to be removed, the circle would be the "default_fill_color" the first frame only, then changed in to red as specified by settings.fill_color.